### PR TITLE
deprecate use of unset_index_in_related_content

### DIFF
--- a/utils/utils.php
+++ b/utils/utils.php
@@ -50,7 +50,6 @@ function get_related_types()
   $profile_types = get_supported_profile_types();
 
   $list_related_types = $wp_types + $ckan_types + $profile_types;
-  //sort($list_related_types);
 
   return array_keys($list_related_types);
 }

--- a/utils/utils.php
+++ b/utils/utils.php
@@ -55,27 +55,6 @@ function get_related_types()
   return array_keys($list_related_types);
 }
 
-function unset_index_in_related_content($json_data){
-  if($json_data){
-    $related_content_arr = json_decode(stripslashes($json_data), true);
-    if($related_content_arr){
-      foreach ($related_content_arr as $related_key => $related_arr) {
-        if(isset($related_arr['index'])){
-          unset($related_arr['index']);
-        }
-        $related_content_no_index[] = $related_arr;
-      }
-
-      if($related_content_no_index){
-        $related_content = json_encode($related_content_no_index);
-        return $related_content;
-      }
-    }
-
-    return $json_data;
-  }
-}
-
 function wprelated_output_template($template_url,$data,$atts){
   ob_start();
   require $template_url;

--- a/wp-odm_related.php
+++ b/wp-odm_related.php
@@ -148,11 +148,11 @@ if (!class_exists('Odm_related_content_Plugin')) {
 
           if($_POST['related_content']):
 
-            $related_content_json = unset_index_in_related_content( $_POST['related_content']);
+            $related_content_json = $_POST['related_content'];
+            $related_content = json_decode(stripslashes($related_content_json), true);
 
             add_post_meta( $post_ID, 'related_content', $related_content_json, true);
 
-            $related_content = json_decode(stripslashes($related_content_json), true);
             foreach($all_related_types as $type):
               foreach($related_content as $content):
                 if ($content["type"] == $type):


### PR DESCRIPTION
@Huyeng in order to simplify the logic thus making it run faster, I have implemented this PR which basically removes the use of the function **unset_index_in_related_content** which reduces the number of times the JSON string is converted into JSON and viceversa.

This causes the index value to be stored along the other fields in the **related_content** field, but since this is internal and the editors should not care about it, I believe there is no problem on keeping it (it can be even useful for the moment when/if we implement re-odering)

Question: Is there anything agains this PR?